### PR TITLE
Feat/coupon-page

### DIFF
--- a/src/app/(login-register)/login/page.jsx
+++ b/src/app/(login-register)/login/page.jsx
@@ -58,6 +58,8 @@ export default function Page() {
           placeholder="이메일을 입력해주세요."
           value={email}
           onChange={(e) => setEmail(e.target.value)}
+          type="email"
+          autoComplete="email"
         />
         <LoginInput
           label="비밀번호"
@@ -65,12 +67,13 @@ export default function Page() {
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           type="password"
+          autoComplete="current-password"
         />
         <LoginButton text="로그인" type="submit" />
       </form>
       {error && <ErrorText message={error} />}
       <RedirectText type="login" />
-      <div style={{height: '30px'}}/>
+      <div style={{ height: "30px" }} />
       <RedirectText type="forgotPassword" />
     </>
   );

--- a/src/app/(reset)/layout.jsx
+++ b/src/app/(reset)/layout.jsx
@@ -10,7 +10,6 @@ export default function layout({ children }) {
           <StyledH1>
             비밀번호 변경하기
           </StyledH1>
-          {/* <StyledH2>[윤리적 문제 해결] 이벤트</StyledH2> */}
         </TextContainer>
         {children}
       </MobileDisplay>

--- a/src/app/_component/login/LoginInput.jsx
+++ b/src/app/_component/login/LoginInput.jsx
@@ -8,11 +8,13 @@ export default function CommonInput({
   value,
   onChange,
   type,
+  autoComplete = "off",
 }) {
   return (
     <FlexContainer style={{ gap: 10, marginBottom: 15 }}>
       <LoginLabel>{label}</LoginLabel>
       <StyledTextArea
+        autoComplete={autoComplete}
         placeholder={placeholder}
         value={value}
         onChange={onChange}

--- a/src/app/_component/question/EmailInput.jsx
+++ b/src/app/_component/question/EmailInput.jsx
@@ -2,18 +2,23 @@ import React from "react";
 import { LabelText } from "@/styles/Texts";
 import { FlexContainer } from "@/styles/Containers";
 import styled from "styled-components";
-import { auth } from "@/../lib/firebase";
 
-export default function EmailInput({ email, setEmail }) {
+export default function EmailInput({
+  email,
+  setEmail,
+  type = "email",
+  label = "답변받을 이메일",
+  placeholder = "이메일을 입력해주세요",
+}) {
   return (
     <FlexContainer style={{ gap: 10 }}>
-      <LabelText>답변받을 이메일</LabelText>
+      <LabelText>{label}</LabelText>
       <EmailTextArea
-        placeholder="이메일을 입력해주세요."
+        placeholder={placeholder}
         value={email}
         onChange={(e) => setEmail(e.target.value)}
         maxLength={140}
-        type="email"
+        type={type}
       />
     </FlexContainer>
   );

--- a/src/app/coupon/page.jsx
+++ b/src/app/coupon/page.jsx
@@ -1,134 +1,96 @@
 "use client";
 
 import EmailInput from "@/app/_component/question/EmailInput";
-import { useState } from "react";
-import LoginButton from "../_component/login/LoginButton";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { auth } from "@/../lib/firebase";
 import ErrorText from "@/app/_component/login/ErrorText";
-import SendText from "@/app/_component/reset/SendText";
-import { Main, MobileDisplay, PageContainer } from "@/styles/Containers";
-import { sendPasswordResetEmail } from "firebase/auth";
+import { Main, MobileDisplay } from "@/styles/Containers";
+import { onAuthStateChanged } from "firebase/auth";
 import { CardInfo, LabelText } from "@/styles/Texts";
-import { getAuth } from "firebase/auth";
+import { db } from "@/../lib/firebase";
+import { doc, getDoc, writeBatch } from "firebase/firestore";
+import { WriteBtn } from "@/styles/Buttons";
 
 export default function Page() {
   const [code, setCode] = useState("");
-  const [price, setPrice] = useState("0");
+  const [price, setPrice] = useState("");
   const [isUsed, setIsUsed] = useState(false);
-  const [isOwner, setIsOwner] = useState(true);
-  const [error, setError] = useState(null);
+  const [isOwner, setIsOwner] = useState(true); // 쿠폰 소유자 여부
+  const [error, setError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const [user, setUser] = useState(null);
+  const [couponRef, setCouponRef] = useState(null);
+  const [couponData, setCouponData] = useState(null);
+
   const router = useRouter();
 
-  const auth = getAuth();
-  const user = auth.currentUser;
-
   // 로그인한 유저 정보 및 상품권 정보 불러오기
-  useEffect(async () => {
-    const userRef = doc(db, "coupon", currentUser.uid);
-    const userSnap = await getDoc(userRef);
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, async (currentUser) => {
+      if (currentUser) {
+        setUser(currentUser); // 현재 로그인한 사용자 설정
+        try {
+          const ref = doc(db, "coupon", currentUser.uid);
+          setCouponRef(ref); // couponRef 설정
+          const couponSnap = await getDoc(ref);
 
-    if (userSnap.exists()) {
-      const userData = userSnap.data();
-    } else {
-      setIsOwner(false);
-    }
+          if (couponSnap.exists()) {
+            const data = couponSnap.data();
+            setCouponData(data); // couponData 설정
+            setPrice(data.price); // 금액 업데이트
+            setIsUsed(data.isUsed); // 사용 여부 업데이트
+          } else {
+            setIsOwner(false); // 소유자 아님
+          }
+        } catch (err) {
+          console.error(err);
+          setError("쿠폰 정보를 불러오는 중 문제가 발생했습니다.");
+        } finally {
+          setIsLoading(false);
+        }
+      } else {
+        router.push("/login"); // 로그아웃 상태면 리디렉션
+      }
+    });
 
-    setPrice(userData.price);
-    setIsUsed(userData.isUsed);
+    return () => unsubscribe(); // 구독 해제
   }, []);
 
-  const handleSubmit = async () => {
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+
     setIsLoading(true);
-
+    setError(false);
     try {
-      // 0. doc 존재여부 검사
-      const userRef = doc(db, "coupon", user.uid);
-      const userSnap = await getDoc(userRef);
-      const userData = userSnap.data();
-      const dailyPostCount = userData.dailyPostCount || 0;
+      if (!user) return;
 
-      // 글 작성 제한: 하루 3개 이상 작성했는지 확인
-      if (dailyPostCount >= 3) {
-        alert("하루에 3개 이상의 글을 작성할 수 없습니다.");
+      // 쿠폰을 이미 썼는지 확인.
+      if (isUsed) {
+        alert("상품권이 이미 사용됐습니다.");
         setIsLoading(false);
         return;
       }
 
-      // 1. 이미지 압축
-      const options = {
-        maxSizeMB: 0.45, // 최대 이미지 크기 설정 (1MB)
-        maxWidthOrHeight: 1024, // 최대 가로/세로 크기 설정
-        useWebWorker: true, // 웹 워커 사용 (성능 향상)
-      };
-      const compressedPhoto = await imageCompression(photo, options);
-
-      // 2. 사진을 Firebase Storage에 업로드
-      const photoRef = ref(
-        storage,
-        `photos/${user.uid}/${Date.now()}_${photo.name}`
-      );
-      const uploadResult = await uploadBytes(photoRef, compressedPhoto); // 압축된 이미지 업로드
-
-      // 3. 업로드된 사진의 다운로드 URL 가져오기
-      const photoURL = await getDownloadURL(uploadResult.ref);
-
-      // 4. Firestore에 데이터 저장
-      const formData = {
-        cloverType: activeButton.type,
-        description,
-        photoURL, // 사진 URL 저장
-        createdAt: new Date(), // 작성 시간 저장
-        userId: user.uid, // 사용자의 UID 저장
-        userEmail: user.email, // 사용자의 이메일 저장
-        userDisplayName: user.displayName || "Anonymous", // 사용자의 이름 저장
-      };
-
-      await addDoc(collection(db, "feeds"), formData); // Firestore에 데이터 저장
+      if (!couponData || couponData.code != code.trim()) {
+        setError("코드가 틀렸습니다. 다시 확인해주세요.");
+        setIsLoading(false);
+        return;
+      }
 
       // 5. 배치 쓰기 시작
       const batch = writeBatch(db);
-
-      // 유저의 cloverCounts, dailyPostCount 업데이트
-      batch.update(userRef, {
-        [`totalCloverCount`]: increment(1),
-        [`cloverCounts.${activeButton.type}`]: increment(1),
-        ["dailyPostCount"]: increment(1),
+      // 유저의 isUsed 업데이트
+      batch.update(couponRef, {
+        [`isUsed`]: true,
       });
 
-      // 클로버 타입별 카운트 업데이트
-      const totalRef = doc(db, "total", activeButton.type);
-      const totalSnapshot = await getDoc(totalRef); // 존재 여부 확인
-      if (totalSnapshot.exists()) {
-        batch.update(totalRef, {
-          totalCloverCount: increment(1),
-        });
-      } else {
-        // 해당 문서가 없을 경우 기본값 설정
-        batch.set(totalRef, { totalCloverCount: 1 });
-      }
-
-      // 전체 클로버 총합 (allTotal) 업데이트
-      const allTotalRef = doc(db, "total", "allTotal");
-      const allTotalSnapshot = await getDoc(allTotalRef);
-      if (allTotalSnapshot.exists()) {
-        batch.update(allTotalRef, {
-          totalCloverCount: increment(1),
-        });
-      } else {
-        // 해당 문서가 없을 경우 기본값 설정
-        batch.set(allTotalRef, { totalCloverCount: 1 });
-      }
-
-      // 6. 배치 커밋
       await batch.commit();
+      setIsUsed(true);
     } catch (error) {
-      console.error("Error uploading data: ", error);
+      setError("Error uploading data: ", error);
     } finally {
       setIsLoading(false); // 업로드 완료
-
-      router.push(`/`);
     }
   };
 
@@ -146,22 +108,41 @@ export default function Page() {
           onSubmit={handleSubmit}
         >
           <LabelText>
-            <text style={{ fontSize: "25px" }}>{user.displayName} </text>님은
+            <text style={{ fontSize: "25px" }}>
+              {user ? user.displayName : ""}{" "}
+            </text>
+            님은
           </LabelText>
-          <LabelText>10,000원 상품권을 사용할 수 있습니다</LabelText>
+          {isOwner && (
+            <LabelText>{price}원 상품권을 사용할 수 있습니다</LabelText>
+          )}
+          {!isOwner && <LabelText>사용할 수 있는 상품권이 없습니다</LabelText>}
           <div style={{ height: "20px" }} />
           <CardInfo>사용 기한은 2024년 12월 31일까지 입니다.</CardInfo>
           <CardInfo>사용 완료 시, 해당 페이지는 폐쇄됩니다.</CardInfo>
           <div style={{ height: "40px" }} />
-          <EmailInput
-            label="확인코드"
-            placeholder="확인코드를 입력해주세요."
-            value={code}
-            onChange={(e) => setCode(e.target.value)}
-          />
-          <LoginButton text="사용 확인" type="submit" />
+          {isUsed ? (
+            <div></div>
+          ) : (
+            <EmailInput
+              label="확인코드"
+              placeholder="확인코드를 입력해주세요."
+              email={code}
+              setEmail={(e) => setCode(e)}
+              type="text"
+            />
+          )}
+          <div style={{ height: "15px" }} />
+          <WriteBtn
+            onClick={handleSubmit}
+            disabled={!code || isUsed || !user}
+            $isReady={code && !isUsed && !isLoading}
+          >
+            {isUsed ? "사용 완료" : "사용 확인"}
+          </WriteBtn>
+          {/* <LoginButton text="사용 확인" type="submit" /> */}
         </form>
-        {message && <SendText message={message} />}
+        {isLoading && <div>로딩 중...</div>}
         {error && <ErrorText message={error} />}
         {/* <RedirectText type="resetPassword" /> */}
       </MobileDisplay>

--- a/src/app/coupon/page.jsx
+++ b/src/app/coupon/page.jsx
@@ -14,34 +14,121 @@ import { getAuth } from "firebase/auth";
 
 export default function Page() {
   const [code, setCode] = useState("");
-  const [message, setMessage] = useState("");
+  const [price, setPrice] = useState("0");
+  const [isUsed, setIsUsed] = useState(false);
+  const [isOwner, setIsOwner] = useState(true);
   const [error, setError] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
 
   const auth = getAuth();
   const user = auth.currentUser;
 
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    setError(null);
+  // 로그인한 유저 정보 및 상품권 정보 불러오기
+  useEffect(async () => {
+    const userRef = doc(db, "coupon", currentUser.uid);
+    const userSnap = await getDoc(userRef);
 
-    // 필드가 비어있는지 확인
-    if (!code) {
-      setError("이메일을 입력해주세요.");
-      return;
+    if (userSnap.exists()) {
+      const userData = userSnap.data();
+    } else {
+      setIsOwner(false);
     }
 
+    setPrice(userData.price);
+    setIsUsed(userData.isUsed);
+  }, []);
+
+  const handleSubmit = async () => {
+    setIsLoading(true);
+
     try {
-      await sendPasswordResetEmail(auth, code);
-      setMessage(
-        "비밀번호 재설정 이메일이 전송되었습니다. 이메일을 확인하세요."
+      // 0. doc 존재여부 검사
+      const userRef = doc(db, "coupon", user.uid);
+      const userSnap = await getDoc(userRef);
+      const userData = userSnap.data();
+      const dailyPostCount = userData.dailyPostCount || 0;
+
+      // 글 작성 제한: 하루 3개 이상 작성했는지 확인
+      if (dailyPostCount >= 3) {
+        alert("하루에 3개 이상의 글을 작성할 수 없습니다.");
+        setIsLoading(false);
+        return;
+      }
+
+      // 1. 이미지 압축
+      const options = {
+        maxSizeMB: 0.45, // 최대 이미지 크기 설정 (1MB)
+        maxWidthOrHeight: 1024, // 최대 가로/세로 크기 설정
+        useWebWorker: true, // 웹 워커 사용 (성능 향상)
+      };
+      const compressedPhoto = await imageCompression(photo, options);
+
+      // 2. 사진을 Firebase Storage에 업로드
+      const photoRef = ref(
+        storage,
+        `photos/${user.uid}/${Date.now()}_${photo.name}`
       );
-      setError("");
+      const uploadResult = await uploadBytes(photoRef, compressedPhoto); // 압축된 이미지 업로드
+
+      // 3. 업로드된 사진의 다운로드 URL 가져오기
+      const photoURL = await getDownloadURL(uploadResult.ref);
+
+      // 4. Firestore에 데이터 저장
+      const formData = {
+        cloverType: activeButton.type,
+        description,
+        photoURL, // 사진 URL 저장
+        createdAt: new Date(), // 작성 시간 저장
+        userId: user.uid, // 사용자의 UID 저장
+        userEmail: user.email, // 사용자의 이메일 저장
+        userDisplayName: user.displayName || "Anonymous", // 사용자의 이름 저장
+      };
+
+      await addDoc(collection(db, "feeds"), formData); // Firestore에 데이터 저장
+
+      // 5. 배치 쓰기 시작
+      const batch = writeBatch(db);
+
+      // 유저의 cloverCounts, dailyPostCount 업데이트
+      batch.update(userRef, {
+        [`totalCloverCount`]: increment(1),
+        [`cloverCounts.${activeButton.type}`]: increment(1),
+        ["dailyPostCount"]: increment(1),
+      });
+
+      // 클로버 타입별 카운트 업데이트
+      const totalRef = doc(db, "total", activeButton.type);
+      const totalSnapshot = await getDoc(totalRef); // 존재 여부 확인
+      if (totalSnapshot.exists()) {
+        batch.update(totalRef, {
+          totalCloverCount: increment(1),
+        });
+      } else {
+        // 해당 문서가 없을 경우 기본값 설정
+        batch.set(totalRef, { totalCloverCount: 1 });
+      }
+
+      // 전체 클로버 총합 (allTotal) 업데이트
+      const allTotalRef = doc(db, "total", "allTotal");
+      const allTotalSnapshot = await getDoc(allTotalRef);
+      if (allTotalSnapshot.exists()) {
+        batch.update(allTotalRef, {
+          totalCloverCount: increment(1),
+        });
+      } else {
+        // 해당 문서가 없을 경우 기본값 설정
+        batch.set(allTotalRef, { totalCloverCount: 1 });
+      }
+
+      // 6. 배치 커밋
+      await batch.commit();
     } catch (error) {
-      setError(
-        "비밀번호 재설정 이메일 전송에 실패했습니다. 이메일 주소를 확인하세요."
-      );
-      setMessage("");
+      console.error("Error uploading data: ", error);
+    } finally {
+      setIsLoading(false); // 업로드 완료
+
+      router.push(`/`);
     }
   };
 

--- a/src/app/coupon/page.jsx
+++ b/src/app/coupon/page.jsx
@@ -1,0 +1,83 @@
+"use client";
+
+import EmailInput from "@/app/_component/question/EmailInput";
+import { useState } from "react";
+import LoginButton from "../_component/login/LoginButton";
+import { useRouter } from "next/navigation";
+import { auth } from "@/../lib/firebase";
+import ErrorText from "@/app/_component/login/ErrorText";
+import SendText from "@/app/_component/reset/SendText";
+import { Main, MobileDisplay, PageContainer } from "@/styles/Containers";
+import { sendPasswordResetEmail } from "firebase/auth";
+import { CardInfo, LabelText } from "@/styles/Texts";
+import { getAuth } from "firebase/auth";
+
+export default function Page() {
+  const [code, setCode] = useState("");
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState(null);
+  const router = useRouter();
+
+  const auth = getAuth();
+  const user = auth.currentUser;
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+
+    // 필드가 비어있는지 확인
+    if (!code) {
+      setError("이메일을 입력해주세요.");
+      return;
+    }
+
+    try {
+      await sendPasswordResetEmail(auth, code);
+      setMessage(
+        "비밀번호 재설정 이메일이 전송되었습니다. 이메일을 확인하세요."
+      );
+      setError("");
+    } catch (error) {
+      setError(
+        "비밀번호 재설정 이메일 전송에 실패했습니다. 이메일 주소를 확인하세요."
+      );
+      setMessage("");
+    }
+  };
+
+  return (
+    <Main>
+      <MobileDisplay>
+        <div style={{ height: "15px" }} />
+
+        <form
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+          }}
+          onSubmit={handleSubmit}
+        >
+          <LabelText>
+            <text style={{ fontSize: "25px" }}>{user.displayName} </text>님은
+          </LabelText>
+          <LabelText>10,000원 상품권을 사용할 수 있습니다</LabelText>
+          <div style={{ height: "20px" }} />
+          <CardInfo>사용 기한은 2024년 12월 31일까지 입니다.</CardInfo>
+          <CardInfo>사용 완료 시, 해당 페이지는 폐쇄됩니다.</CardInfo>
+          <div style={{ height: "40px" }} />
+          <EmailInput
+            label="확인코드"
+            placeholder="확인코드를 입력해주세요."
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+          />
+          <LoginButton text="사용 확인" type="submit" />
+        </form>
+        {message && <SendText message={message} />}
+        {error && <ErrorText message={error} />}
+        {/* <RedirectText type="resetPassword" /> */}
+      </MobileDisplay>
+    </Main>
+  );
+}

--- a/src/app/write/page.jsx
+++ b/src/app/write/page.jsx
@@ -22,9 +22,10 @@ import PerCount from "@/app/_component/write/PerCount";
 import PhotoInput from "@/app/_component/write/PhotoInput";
 import CloverTypeButtons from "@/app/_component/write/CloverTypeButtons";
 import DescriptionInput from "@/app/_component/write/DescriptionInput";
-import styled from "styled-components";
+
 import { cloverTypes } from "../_constants/type";
 import imageCompression from "browser-image-compression"; // 이미지 압축 라이브러리
+import { WriteBtn } from "@/styles/Buttons";
 
 export default function WritePage() {
   const [activeButton, setActiveButton] = useState(cloverTypes[0]);
@@ -182,21 +183,3 @@ export default function WritePage() {
     </Main>
   );
 }
-
-const WriteBtn = styled.button`
-  width: 320px;
-  height: 56px;
-  border-radius: 10px;
-  background: ${({ $isReady }) => ($isReady ? "#7CE28D" : "#e0e5ea")};
-  font-size: 18px;
-  font-weight: bold;
-  color: ${({ $isReady }) => ($isReady ? "#ffffff" : "#A6ABAF")};
-  cursor: ${({ $isReady }) => ($isReady ? "pointer" : "not-allowed")};
-  border: none;
-
-  &:disabled {
-    background: #e0e5ea;
-    color: #a6abaf;
-    cursor: not-allowed;
-  }
-`;

--- a/src/components/TopNav.jsx
+++ b/src/components/TopNav.jsx
@@ -84,6 +84,7 @@ export default function TopNav() {
               <li onClick={() => handleMenuItemClick("/write")}>글쓰기</li>
               <li onClick={() => handleMenuItemClick("/rank")}>랭킹</li>
               <li onClick={() => handleMenuItemClick("/question")}>문의하기</li>
+              <li onClick={() => handleMenuItemClick("/coupon")}>상품권 확인</li>
               <li style={{ marginTop: "60px" }}>
                 <InstaIcon />
               </li>

--- a/src/styles/Buttons.jsx
+++ b/src/styles/Buttons.jsx
@@ -11,4 +11,23 @@ const CloverButton = styled.div`
   align-items: center;
 `;
 
-export { CloverButton };
+const WriteBtn = styled.button`
+  width: 320px;
+  height: 56px;
+  border-radius: 10px;
+  background: ${({ $isReady }) => ($isReady ? "#7CE28D" : "#e0e5ea")};
+  font-size: 18px;
+  font-weight: bold;
+  color: ${({ $isReady }) => ($isReady ? "#ffffff" : "#A6ABAF")};
+  cursor: ${({ $isReady }) => ($isReady ? "pointer" : "not-allowed")};
+  border: none;
+
+  &:disabled {
+    background: #e0e5ea;
+    color: #a6abaf;
+    cursor: not-allowed;
+  }
+`;
+
+
+export { CloverButton, WriteBtn };

--- a/src/styles/Texts.jsx
+++ b/src/styles/Texts.jsx
@@ -75,6 +75,7 @@ const CountText = styled.text`
 `;
 
 const LabelText = styled.text`
+  letter-spacing: -0.3px;
   font-size: 20px;
   font-weight: 500;
   color: #191b1c;


### PR DESCRIPTION
## ✅ PR 설명
- [x] 쿠폰 페이지 퍼블리싱
- [x] 서버 DB에 쿠폰 테이블 생성
- [x] 코드 입력 시, 상품권 사용 확인 기능 추가
- [x] 내비게이션 탭에 쿠폰페이지 추가


## 📝 작업 내용
<!-- 상세 작업 내용 기재 -->
### 쿠폰 페이지 퍼블리싱
- 쿠폰 페이지 디자인
- UI 구현
- 로그인 정보와 DB의 상품권 등록 uid 정보를 비교해서, 해당 유저가 상품권을 가지고 있을 경우 '상품권 액수'를 출력하는 기능 구현.
- 만약 상품권이 없을 경우, '사용할 수 있는 상품권이 없다.'는 문구 안내

### 서버 DB에 쿠폰 테이블 생성
- 사용자 이름을 doc의 이름으로 지정해서, 상품권 소유자일 때 상품권 정보에 접근 가능하게 유도
- isUsed(상품권 사용 여부), price(상품권 액수) 필드 지정

### 코드 입력 시, 상품권 사용 확인 기능 추가
- 코드가 틀리면, 틀렸다고 안내
- 로그아웃 상태에서 상품권 페이지에 접속하면, 로그인 페이지로 바로 리다이렉트
- 사용 완료 시, 코드 입력 창을 막고, 버튼이 비활성화 되며, 사용완료 문구만 뜸.


### 내비게이션 탭에 쿠폰페이지 연결
- '상품권 확인' 버튼을 누르면, /coupon 페이지로 이동.


## 📸 스크린샷 / GIF / Link
![image](https://github.com/user-attachments/assets/3e360e4c-76ca-4db0-bd93-87b3e78f8bbd)
![image](https://github.com/user-attachments/assets/ae0fce78-2604-4ee0-a3cb-161bf7480d39)
![image](https://github.com/user-attachments/assets/b7a0646a-34c4-439a-b87a-a9dcb18b18df)
![image](https://github.com/user-attachments/assets/ab9c8acd-cb01-4b98-a81c-86a18bac1ccc)
![image](https://github.com/user-attachments/assets/fbeb7c6b-49f7-4f23-a575-2bfd1679527e)



